### PR TITLE
Add require_admin helper

### DIFF
--- a/app/ui.php
+++ b/app/ui.php
@@ -52,7 +52,16 @@ function post_only(): void {
   if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') { http_response_code(405); exit('Method Not Allowed'); }
   csrf_verify();
 }
-function require_login(): void { if (empty($_SESSION['user'])) { header('Location: ' . url_for('/login')); exit; } }
+function require_login(): void {
+  if (empty($_SESSION['user'])) {
+    header('Location: ' . url_for('/login'));
+    exit;
+  }
+}
+function require_admin(): void {
+  require_login();
+  if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+}
 function role_is(string $role): bool {
   return !empty($_SESSION['user']) && ($_SESSION['user']['role'] === $role || $_SESSION['user']['role'] === 'admin');
 }

--- a/routes/admin_tools.php
+++ b/routes/admin_tools.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  */
 
 $router->get('/admin/tools', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
 
   $tok = csrf_token();
   $body = "<h1>Admin tools</h1>
@@ -31,7 +31,7 @@ $router->get('/admin/tools', function () {
 });
 
 $router->post('/admin/tools/wac-recalc', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); // post_only() already calls csrf_verify()
   global $pdo;
 
@@ -44,7 +44,7 @@ $router->post('/admin/tools/wac-recalc', function () {
 });
 
 $router->get('/admin/tools/log', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
 
   // Try to read error_log (path from PHP config). If not readable, say so.
   $path = ini_get('error_log') ?: __DIR__ . '/../error_log';
@@ -65,7 +65,7 @@ $router->get('/admin/tools/log', function () {
 });
 
 $router->get('/admin/tools/normalize-po', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   if (!function_exists('find_po_lines_needing_normalization')) { require_once __DIR__ . '/../app/po_normalize_tools.php'; }
   global $pdo;
 
@@ -99,7 +99,7 @@ $router->get('/admin/tools/normalize-po', function() {
 });
 
 $router->post('/admin/tools/normalize-po/apply', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   if (!function_exists('find_po_lines_needing_normalization')) { require_once __DIR__ . '/../app/po_normalize_tools.php'; }
   post_only(); global $pdo;
 
@@ -123,7 +123,7 @@ $router->post('/admin/tools/normalize-po/apply', function() {
 });
 
 $router->get('/admin/tools/fix-and-recalc', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   if (!function_exists('find_po_lines_needing_normalization')) { require_once __DIR__ . '/../app/po_normalize_tools.php'; }
   global $pdo;
 
@@ -140,7 +140,7 @@ $router->get('/admin/tools/fix-and-recalc', function() {
 });
 
 $router->get('/admin/timecheck', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
 
   $phpNow = date('Y-m-d H:i:s T');

--- a/routes/enrich.php
+++ b/routes/enrich.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 $router->get('/admin/enrich', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   if (!function_exists('enrich_one')) { http_response_code(404); render('Enrich', "<p class='err'>Enrichment module not installed.</p>"); return; }
   global $pdo;
   $rows = $pdo->query("SELECT id,name,solids_pct,fat_pct,sugar_pct,nutrition_source,nutrition_confidence FROM ingredients WHERE is_active=1 ORDER BY name")->fetchAll();
@@ -19,7 +19,7 @@ $router->get('/admin/enrich', function() {
 });
 
 $router->get('/admin/enrich/run', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   if (!function_exists('enrich_one')) { http_response_code(404); render('Enrich', "<p class='err'>Enrichment module not installed.</p>"); return; }
   global $pdo;
   $id = (int)($_GET['id'] ?? 0); if ($id<=0) { http_response_code(400); exit('Bad id'); }

--- a/routes/fx_admin.php
+++ b/routes/fx_admin.php
@@ -1,6 +1,6 @@
 <?php
 $router->get('/admin/fx', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
 
   global $pdo;
   $rows = $pdo->query("
@@ -45,7 +45,7 @@ $router->get('/admin/fx', function() {
 });
 
 $router->post('/admin/fx/save', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only();
 
   global $pdo;
@@ -67,7 +67,7 @@ $router->post('/admin/fx/save', function() {
 });
 
 $router->post('/admin/fx/bulk', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only();
 
   global $pdo;
@@ -96,7 +96,7 @@ $router->post('/admin/fx/bulk', function() {
 });
 
 $router->get('/admin/fx/export', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   header('Content-Type: text/csv; charset=UTF-8');
   header('Content-Disposition: attachment; filename="exchange_rates.csv"');
   global $pdo;

--- a/routes/fx_api.php
+++ b/routes/fx_api.php
@@ -1,6 +1,6 @@
 <?php
 $router->get('/fx/quote', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   header('Content-Type: application/json');
   $date = $_GET['date'] ?? date('Y-m-d');
   $cur  = strtoupper($_GET['currency'] ?? 'BWP');

--- a/routes/ingredients.php
+++ b/routes/ingredients.php
@@ -51,7 +51,7 @@ $router->get('/ingredients', function() {
 });
 
 $router->get('/ingredients/edit', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
 
   $id = (int)($_GET['id'] ?? 0);
@@ -107,7 +107,7 @@ $router->get('/ingredients/edit', function() {
 });
 
 $router->post('/ingredients/update', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $stmt = $pdo->prepare("UPDATE ingredients
     SET name=?, category=?, unit_kind=?, reorder_point=?, solids_pct=?, fat_pct=?, sugar_pct=?, is_active=?
@@ -125,7 +125,7 @@ $router->post('/ingredients/update', function() {
 });
 
 $router->get('/ingredients/delete', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
   $id = (int)($_GET['id'] ?? 0);
   $pdo->prepare("UPDATE ingredients SET is_active=0 WHERE id=?")->execute([$id]);
@@ -133,7 +133,7 @@ $router->get('/ingredients/delete', function() {
 });
 
 $router->post('/ingredients/create', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $stmt = $pdo->prepare("INSERT INTO ingredients (name, category, unit_kind, reorder_point, solids_pct, fat_pct, sugar_pct, is_active) VALUES (?,?,?,?,?,?,?,1)");
   $stmt->execute([

--- a/routes/inventory.php
+++ b/routes/inventory.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  */
 
 $router->get('/inventory/adjust', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
 
   $id = (int)($_GET['id'] ?? 0);
@@ -62,7 +62,7 @@ $router->get('/inventory/adjust', function () {
 });
 
 $router->post('/inventory/adjust/usage', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   csrf_verify(); global $pdo;
 
   $iid  = (int)($_POST['ingredient_id'] ?? 0);
@@ -93,7 +93,7 @@ $router->post('/inventory/adjust/usage', function () {
 });
 
 $router->post('/inventory/adjust/set-on-hand', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   csrf_verify(); global $pdo;
 
   $iid   = (int)($_POST['ingredient_id'] ?? 0);
@@ -132,7 +132,7 @@ $router->post('/inventory/adjust/set-on-hand', function () {
 });
 
 $router->get('/inventory/history', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
 
   $id = (int)($_GET['id'] ?? 0);

--- a/routes/po.php
+++ b/routes/po.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
     // ---- LIST: GET /po ----
     if ($is('GET','/po')) {
-      require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+      require_admin();
     
       $rows = $pdo->query("
         SELECT
@@ -64,7 +64,7 @@ declare(strict_types=1);
 
   // ---- VIEW: GET /po/view?id=... ----
   if ($is('GET','/po/view')) {
-    require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+    require_admin();
     $id = (int)($_GET['id'] ?? 0); if ($id<=0) { http_response_code(400); exit('Bad id'); }
 
     $po = $pdo->prepare("
@@ -113,7 +113,7 @@ declare(strict_types=1);
 
   // ---- NEW: GET /po/new ----
   if ($is('GET','/po/new')) {
-    require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+    require_admin();
     $ing = $pdo->query("SELECT id,name,unit_kind FROM ingredients WHERE is_active=1 ORDER BY name")->fetchAll();
     $opt = ""; foreach ($ing as $i) { $opt .= "<option value='".(int)$i['id']."'>".h($i['name'])." (".h($i['unit_kind']).")</option>"; }
 
@@ -212,7 +212,7 @@ declare(strict_types=1);
 
   // ---- SAVE: POST /po/save ----
   if ($is('POST','/po/save')) {
-    require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+    require_admin();
     csrf_verify();
 
     db_tx(function(PDO $pdo) {
@@ -288,7 +288,7 @@ declare(strict_types=1);
 
   // ---- EDIT: GET /po/edit?id=... ----
   if ($is('GET','/po/edit')) {
-    require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+    require_admin();
     $id = (int)($_GET['id'] ?? 0); if ($id<=0) { http_response_code(400); exit('Bad id'); }
 
     $po = $pdo->prepare("
@@ -395,7 +395,7 @@ declare(strict_types=1);
 
   // ---- UPDATE: POST /po/update ----
   if ($is('POST','/po/update')) {
-    require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+    require_admin();
     csrf_verify();
 
     $id          = (int)($_POST['id'] ?? 0);

--- a/routes/recipes.php
+++ b/routes/recipes.php
@@ -70,7 +70,7 @@ $router->get('/recipes', function () {
 });
 
 $router->post('/recipes/create', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only();
   global $pdo;
 
@@ -109,7 +109,7 @@ $router->post('/recipes/create', function () {
 
 /* ---------- New version ---------- */
 $router->get('/recipes/newversion', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
   $recipe_id = (int)($_GET['recipe_id'] ?? 0);
   if ($recipe_id<=0) { http_response_code(400); exit('Bad recipe id'); }
@@ -138,7 +138,7 @@ $router->get('/recipes/newversion', function () {
 });
 
 $router->post('/recipes/newversion/save', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
 
   $st = $pdo->prepare("
@@ -166,7 +166,7 @@ $router->post('/recipes/newversion/save', function () {
 
 /* ---------- Inline editor for package weights ---------- */
 $router->post('/recipes/version/weights', function () {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
 
   $rv_id = (int)($_POST['rv_id'] ?? 0);
@@ -489,7 +489,7 @@ $router->get('/recipes/items', function() {
 
 /* ---------- Item CRUD ---------- */
 $router->get('/recipes/items/edit', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
   $id = (int)($_GET['id'] ?? 0);
   $st = $pdo->prepare('SELECT ri.*, i.name FROM recipe_items ri JOIN ingredients i ON i.id=ri.ingredient_id WHERE ri.id=?');
@@ -516,7 +516,7 @@ $router->get('/recipes/items/edit', function() {
 });
 
 $router->post('/recipes/items/update', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $rv_id = (int)($_POST['rv_id'] ?? 0);
   $stmt = $pdo->prepare("UPDATE recipe_items
@@ -535,7 +535,7 @@ $router->post('/recipes/items/update', function() {
 });
 
 $router->post('/recipes/items/delete', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $rv_id = (int)($_POST['rv_id'] ?? 0);
   $id    = (int)($_POST['id'] ?? 0);
@@ -545,7 +545,7 @@ $router->post('/recipes/items/delete', function() {
 });
 
 $router->post('/recipes/items/add', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
 
   $rv_id        = (int)($_POST['rv_id'] ?? 0);
@@ -592,7 +592,7 @@ $router->post('/recipes/items/add', function() {
 
 /* ---------- Steps ---------- */
 $router->post('/recipes/steps/add', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $rv_id  = (int)($_POST['rv_id'] ?? 0);
   $instr  = trim($_POST['instruction'] ?? '');
@@ -626,7 +626,7 @@ $router->post('/recipes/steps/add', function() {
 });
 
 $router->post('/recipes/steps/add-from-library', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $rv_id = (int)($_POST['rv_id'] ?? 0);
   $libId = (int)($_POST['library_id'] ?? 0);
@@ -656,7 +656,7 @@ $router->post('/recipes/steps/add-from-library', function() {
 });
 
 $router->get('/recipes/steps/edit', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   global $pdo;
   $id = (int)($_GET['id'] ?? 0);
   $st = $pdo->prepare('SELECT * FROM recipe_steps WHERE id=?');
@@ -677,7 +677,7 @@ $router->get('/recipes/steps/edit', function() {
 });
 
 $router->post('/recipes/steps/update', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
 
   $id = (int)($_POST['id'] ?? 0);
@@ -719,7 +719,7 @@ $router->post('/recipes/steps/update', function() {
 });
 
 $router->post('/recipes/steps/delete', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $id = (int)($_POST['id'] ?? 0);
   $rv_id = (int)($_POST['rv_id'] ?? 0);
@@ -738,7 +738,7 @@ $router->post('/recipes/steps/delete', function() {
 });
 
 $router->post('/recipes/steps/move', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $id = (int)($_POST['id'] ?? 0);
   $rv_id = (int)($_POST['rv_id'] ?? 0);
@@ -775,7 +775,7 @@ $router->post('/recipes/steps/move', function() {
 });
 
 $router->post('/recipes/steps/clone', function() {
-  require_login(); if (!role_is('admin')) { http_response_code(403); exit('Forbidden'); }
+  require_admin();
   post_only(); global $pdo;
   $rv_id = (int)($_POST['rv_id'] ?? 0);
   $from  = (int)$_POST['from_rv_id'];


### PR DESCRIPTION
## Summary
- add a `require_admin()` helper alongside `require_login()` in `app/ui.php`
- replace repeated admin-guard boilerplate across admin routes with the new helper

## Testing
- php -l app/ui.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe627021c83219afbe27188c7f211