### PR TITLE
Add csrf_field helper and refactor CSRF inputs

### DIFF
--- a/app/csrf.php
+++ b/app/csrf.php
@@ -11,8 +11,8 @@ function csrf_token(): string {
     return $t;
 }
 
-function csrf_field(): string {
-    $tok = htmlspecialchars(csrf_token(), ENT_QUOTES, 'UTF-8');
+function csrf_field(?string $token = null): string {
+    $tok = htmlspecialchars($token ?? csrf_token(), ENT_QUOTES, 'UTF-8');
     return "<input type='hidden' name='_csrf' value='".$tok."'>";
 }
 

--- a/routes/admin_tools.php
+++ b/routes/admin_tools.php
@@ -16,7 +16,7 @@ $router->get('/admin/tools', function () {
   $tok = csrf_token();
   $body = "<h1>Admin tools</h1>
   <form method='post' action='".url_for("/admin/tools/wac-recalc")."' onsubmit='return confirm(\"Recalculate WAC for all ingredients?\")'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <button>Recalculate WAC (all)</button>
   </form>
 
@@ -92,7 +92,7 @@ $router->get('/admin/tools/normalize-po', function() {
   $tbl .= "</table>";
 
   $form = "<form method='post' action='".url_for("/admin/tools/normalize-po/apply")."'>"
-        . "<input type='hidden' name='_csrf' value='".h($tok)."'>"
+        . csrf_field($tok)
         . "<button>Apply normalization to ".count($rows)." line(s)</button></form>";
 
   render('Normalize PO', "<h1>Normalize PO Unit Costs</h1><p>This will convert line totals into per-unit costs and fix WAC.</p>{$tbl}{$form}<p><a href='".url_for("/ingredients")."'>Back</a></p>");
@@ -133,7 +133,7 @@ $router->get('/admin/tools/fix-and-recalc', function() {
   $count = count($rows);
 
   $btn = "<form method='post' action='".url_for("/admin/tools/normalize-po/apply".($iid ? ("?id=".$iid) : ""))."'>"
-       . "<input type='hidden' name='_csrf' value='".h($tok)."'>"
+       . csrf_field($tok)
        . "<button>Fix ".($iid ? ("ingredient ".(int)$iid) : "all ingredients")." ({$count} line(s))</button></form>";
 
   render('Fix & Recalc', "<h1>Fix & Recalc</h1><p>Detected ".(int)$count." line(s) needing normalization.</p>{$btn}");

--- a/routes/batches.php
+++ b/routes/batches.php
@@ -163,7 +163,7 @@ $router->get('/batches/new', function() {
 
   $hdr = "<h1>New Batch — ".h($v['recipe_name'])." v".(int)$v['version_no']."</h1>
     <form method='post' action='".url_for("/batches/save")."' id='batchForm'>
-      <input type='hidden' name='_csrf' value='".h($tok)."'>
+      " . csrf_field($tok) . "
       <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
       <input type='hidden' name='default_yield' value='".number_format((float)$v['default_yield_g'],3,'.','')."'>
 
@@ -556,7 +556,7 @@ $router->get('/batches/edit', function () {
   
   $hdr = "<h1>Edit Batch #".(int)$B['id']." — ".h($B['recipe_name'])." v".(int)$B['version_no']."</h1>
   <form method='post' action='".url_for("/batches/update")."' id='batchEdit'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <input type='hidden' name='id' value='".(int)$B['id']."'>
     <input type='hidden' name='default_yield' value='".number_format((float)$B['default_yield_g'],3,'.','')."'>
 

--- a/routes/ingredients.php
+++ b/routes/ingredients.php
@@ -33,7 +33,7 @@ $router->get('/ingredients', function() {
     $tok = csrf_token();
     $form = "<h2>Add Ingredient</h2>
       <form method='post' action='".url_for("/ingredients/create")."' class='row'>
-        <input type='hidden' name='_csrf' value='".h($tok)."'>
+        " . csrf_field($tok) . "
         <div class='col'><label>Name <input name='name' required></label></div>
         <div class='col'><label>Category <input name='category'></label></div>
         <div class='col'><label>Unit
@@ -79,7 +79,7 @@ $router->get('/ingredients/edit', function() {
   $body = "<h1>Edit ingredient — ".h($ing['name'])."</h1>
   {$quick}
   <form method='post' action='".url_for("/ingredients/update")."'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <input type='hidden' name='id' value='".(int)$ing['id']."'>
     <label>Name <input name='name' value='".h($ing['name'])."'></label>
     <label>Category <input name='category' value='".h((string)$ing['category'])."'></label>

--- a/routes/inventory.php
+++ b/routes/inventory.php
@@ -38,7 +38,7 @@ $router->get('/inventory/adjust', function () {
 
   <h2>Record a deduction</h2>
   <form method='post' action='".url_for('/inventory/adjust/usage')."' class='row'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <input type='hidden' name='ingredient_id' value='".(int)$row['id']."'>
     <div class='col'><label>Date <input type='date' name='date' value='".h($today)."' required></label></div>
     <div class='col'><label>Qty to deduct ({$unit}) <input type='number' name='qty' step='0.001' min='0.001' required></label></div>
@@ -48,7 +48,7 @@ $router->get('/inventory/adjust', function () {
 
   <h2>Set on-hand to an exact amount</h2>
   <form method='post' action='".url_for('/inventory/adjust/set-on-hand')."' class='row'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <input type='hidden' name='ingredient_id' value='".(int)$row['id']."'>
     <div class='col'><label>Date <input type='date' name='date' value='".h($today)."' required></label></div>
     <div class='col'><label>Target on hand ({$unit}) <input type='number' name='target_qty' step='0.001' min='0' required></label></div>

--- a/routes/po.php
+++ b/routes/po.php
@@ -130,7 +130,7 @@ declare(strict_types=1);
 
     $body = "<h1>New Purchase Order</h1>
     <form method='post' action='".url_for("/po/save")."' id='poForm'>
-      <input type='hidden' name='_csrf' value='".h($tok)."'>
+      " . csrf_field($tok) . "
       <div class='row'>
         <div class='col'><label>PO Number <input name='po_number'></label></div>
         <div class='col'><label>Supplier (free text) <input name='supplier'></label></div>
@@ -323,7 +323,7 @@ declare(strict_types=1);
 
     $hdr = "<h1>Edit PO ".h((string)$H['po_number'])."</h1>
       <form method='post' action='".url_for("/po/update")."' id='poEdit'>
-        <input type='hidden' name='_csrf' value='".h($tok)."'>
+        " . csrf_field($tok) . "
         <input type='hidden' name='id' value='".(int)$id."'>
         <div class='row'>
           <div class='col'><label>PO Number <input name='po_number' value='".h((string)$H['po_number'])."'></label></div>

--- a/routes/recipes.php
+++ b/routes/recipes.php
@@ -51,7 +51,7 @@ $router->get('/recipes', function () {
     $tok = csrf_token();
     $form = "<h2>Create Recipe + Version</h2>
       <form method='post' action='".url_for("/recipes/create")."' class='row'>
-        <input type='hidden' name='_csrf' value='".h($tok)."'>
+        " . csrf_field($tok) . "
         <div class='col'><label>Recipe name <input name='name' required></label></div>
         <div class='col'><label>Style
           <select name='style'><option>gelato</option><option>sorbet</option><option>other</option></select></label></div>
@@ -120,7 +120,7 @@ $router->get('/recipes/newversion', function () {
 
   $body = "<h1>New Version</h1>
   <form method='post' action='".url_for("/recipes/newversion/save")."'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <input type='hidden' name='recipe_id' value='".(int)$recipe_id."'>
     <label>Version # <input name='version_no' type='number' value='".(int)$nextv."'></label>
     <label>Default yield (g) <input name='yield' type='number' step='0.001' value='1100'></label>
@@ -335,7 +335,7 @@ $router->get('/recipes/items', function() {
         <td>
           <a href='".url_for("/recipes/items/edit?id=".(int)$r['id'])."'>Edit</a>
           <form method='post' action='".url_for("/recipes/items/delete")."' style='display:inline' onsubmit='return confirm(\"Remove this item?\")'>
-            <input type='hidden' name='_csrf' value='".h($tok)."'>
+            " . csrf_field($tok) . "
             <input type='hidden' name='id' value='".(int)$r['id']."'>
             <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
             <button class='link danger'>Remove</button>
@@ -352,7 +352,7 @@ $router->get('/recipes/items', function() {
   if (role_is('admin')) {
     $pkgForm = "
       <form method='post' action='".url_for("/recipes/version/weights")."' class='row' style='gap:.75rem;align-items:end;margin-top:.35rem'>
-        <input type='hidden' name='_csrf' value='".h($tokPkg)."'>
+        " . csrf_field($tokPkg) . "
         <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
         <div class='col'><label>Quart est (g)
           <input name='quart_est_g' type='number' step='0.01' value='".h((string)$version['quart_est_g'])."'></label></div>
@@ -387,7 +387,7 @@ $router->get('/recipes/items', function() {
   $tok = csrf_token();
   $form = "<h3>Add ingredient to version</h3>
     <form method='post' action='".url_for("/recipes/items/add")."' class='row'>
-      <input type='hidden' name='_csrf' value='".h($tok)."'>
+      " . csrf_field($tok) . "
       <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
       <div class='col'><label>Ingredient <select name='ingredient_id'>{$opt}</select></label></div>
       <div class='col'><label>Qty <input type='number' name='qty' step='0.001' required></label></div>
@@ -408,16 +408,18 @@ $router->get('/recipes/items', function() {
   foreach ($steps as $s) {
     $steps_html .= "<li>"
       . h($s['instruction'])
-      . " <form method='post' action='".url_for("/recipes/steps/move")."' style='display:inline'>
-           <input type='hidden' name='_csrf' value='".h($tokSteps)."'>
+      . " <form method='post' action='".url_for("/recipes/steps/move")."' style='display:inline'>"
+      . csrf_field($tokSteps)
+      . "
            <input type='hidden' name='id' value='".(int)$s['id']."'>
            <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
            <button class='link' name='dir' value='up'>&uarr;</button>
            <button class='link' name='dir' value='down'>&darr;</button>
           </form>
           <a href='".url_for("/recipes/steps/edit?id=".(int)$s['id'])."'>Edit</a>
-          <form method='post' action='".url_for("/recipes/steps/delete")."' style='display:inline' onsubmit='return confirm(\"Delete this step?\")'>
-            <input type='hidden' name='_csrf' value='".h($tokSteps)."'>
+          <form method='post' action='".url_for("/recipes/steps/delete")."' style='display:inline' onsubmit='return confirm(\"Delete this step?\")'>"
+      . csrf_field($tokSteps)
+      . "
             <input type='hidden' name='id' value='".(int)$s['id']."'>
             <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
             <button class='link danger'>Delete</button>
@@ -433,7 +435,7 @@ $router->get('/recipes/items', function() {
   $tok_step = csrf_token();
   $steps_form = "<h4>Add step</h4>
     <form method='post' action='".url_for("/recipes/steps/add")."' class='row'>
-      <input type='hidden' name='_csrf' value='".h($tok_step)."'>
+      " . csrf_field($tok_step) . "
       <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
       <div class='col'><label>Step # <input name='step_no' type='number' min='1' value='".(int)$next_no."'></label></div>
       <div class='col' style='flex:2'><label>Instruction <input name='instruction' required placeholder='e.g., Heat milk to 45°C; dissolve sugars; chill…'></label></div>
@@ -451,7 +453,7 @@ $router->get('/recipes/items', function() {
     $tok_lib = csrf_token();
     $steps_form .= "<h4>Insert from library</h4>
       <form method='post' action='".url_for("/recipes/steps/add-from-library")."' class='row'>
-        <input type='hidden' name='_csrf' value='".h($tok_lib)."'>
+        " . csrf_field($tok_lib) . "
         <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
         <div class='col'><label>Step # <input name='step_no' type='number' min='1' value='".(int)$next_no."'></label></div>
         <div class='col' style='flex:2'><label>Library <select name='library_id'>{$opts}</select></label></div>
@@ -476,7 +478,7 @@ $router->get('/recipes/items', function() {
     $tok_clone = csrf_token();
     $steps_form .= "<h4>Clone steps from another version</h4>
       <form method='post' action='".url_for("/recipes/steps/clone")."' class='row' onsubmit='return confirm(\"Append all steps from the selected version?\")'>
-        <input type='hidden' name='_csrf' value='".h($tok_clone)."'>
+        " . csrf_field($tok_clone) . "
         <input type='hidden' name='rv_id' value='".(int)$rv_id."'>
         <div class='col' style='flex:2'><label>Source version <select name='from_rv_id'>{$o}</select></label></div>
         <button>Clone steps</button>
@@ -498,7 +500,7 @@ $router->get('/recipes/items/edit', function() {
   $tok = csrf_token();
   $body = "<h1>Edit item — ".h($ri['name'])."</h1>
   <form method='post' action='".url_for("/recipes/items/update")."'>
-    <input type='hidden' name='_csrf' value='".h($tok)."'>
+    " . csrf_field($tok) . "
     <input type='hidden' name='id' value='".(int)$ri['id']."'>
     <input type='hidden' name='rv_id' value='".(int)$ri['recipe_version_id']."'>
     <label>Choice group <input type='number' name='choice_group' value='".(int)$ri['choice_group']."'></label>
@@ -665,7 +667,7 @@ $router->get('/recipes/steps/edit', function() {
   $tok = csrf_token();
   $body = "<h1>Edit step</h1>
     <form method='post' action='".url_for("/recipes/steps/update")."'>
-      <input type='hidden' name='_csrf' value='".h($tok)."'>
+      " . csrf_field($tok) . "
       <input type='hidden' name='id' value='".(int)$row['id']."'>
       <input type='hidden' name='rv_id' value='".(int)$row['recipe_version_id']."'>
       <label>Step # <input name='step_no' type='number' min='1' value='".(int)$row['step_no']."'></label>


### PR DESCRIPTION
## Summary
- add a csrf_field() helper that returns a hidden _csrf field and accepts an optional token
- use the helper across route forms instead of hand-written hidden inputs while keeping existing token handling

## Testing
- for f in app/csrf.php routes/admin_tools.php routes/batches.php routes/ingredients.php routes/inventory.php routes/po.php routes/recipes.php; do php -l "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68cbe6104be883219d7815009ac26db8