### PR TITLE
Ensure all tables share styling helper

### DIFF
--- a/app/ui.php
+++ b/app/ui.php
@@ -5,6 +5,14 @@ function pretty_urls(): bool { return ($_ENV['PRETTY_URLS'] ?? '0') === '1'; }
 function url_for(string $p): string { return pretty_urls() ? $p : '/?r=' . ltrim($p, '/'); }
 function h(string $s): string { return htmlspecialchars($s, ENT_QUOTES, 'UTF-8'); }
 
+/** Helper for consistent table styling */
+function table_open(string $attrs = ''): string {
+  $attrs = trim($attrs);
+  return $attrs === ''
+    ? "<table class='table'>"
+    : "<table class='table' " . $attrs . ">";
+}
+
 /** Safe read of var/REVISION (returns null if missing/unreadable) */
 function get_build_revision(): ?string {
   $path = __DIR__ . '/../var/REVISION';

--- a/routes/admin_tools.php
+++ b/routes/admin_tools.php
@@ -78,7 +78,7 @@ $router->get('/admin/tools/normalize-po', function() {
   }
 
   $tok = csrf_token();
-  $tbl = "<table><tr><th>POL</th><th>Ingredient</th><th class='right'>Qty</th><th class='right'>FX</th><th class='right'>Current itxn unit BWP</th><th class='right'>Expected per-unit BWP</th></tr>";
+  $tbl = table_open() . "<tr><th>POL</th><th>Ingredient</th><th class='right'>Qty</th><th class='right'>FX</th><th class='right'>Current itxn unit BWP</th><th class='right'>Expected per-unit BWP</th></tr>";
   foreach ($rows as $r) {
     $tbl .= "<tr>"
           . "<td>".h((string)$r['pol_id'])."</td>"

--- a/routes/batches.php
+++ b/routes/batches.php
@@ -46,8 +46,8 @@ $router->get('/batches', function () {
   }
   $nav = $navLinks ? "<p class='pager'>".implode(' | ', $navLinks)."</p>" : '';
 
-  $tbl = "<table>
-    <tr><th>Date</th><th>Recipe</th><th>v</th><th class='right'>Target (g)</th><th class='right'>Actual (g)</th><th class='right'>COGS (BWP)</th><th>Actions</th></tr>";
+  $tbl = table_open()
+    . "<tr><th>Date</th><th>Recipe</th><th>v</th><th class='right'>Target (g)</th><th class='right'>Actual (g)</th><th class='right'>COGS (BWP)</th><th>Actions</th></tr>";
   foreach ($rows as $r) {
     $tbl .= "<tr>
       <td>".h(date('Y-m-d H:i', strtotime($r['batch_date'])))."</td>
@@ -93,7 +93,7 @@ $router->get('/batches/view', function () {
   ");
   $res->execute([$id]); $rows = $res->fetchAll();
 
-  $tbl = "<table><tr><th>Ingredient</th><th class='right'>Measured</th><th>Unit</th><th class='right'>WAC</th><th class='right'>Ext (BWP)</th></tr>";
+  $tbl = table_open() . "<tr><th>Ingredient</th><th class='right'>Measured</th><th>Unit</th><th class='right'>WAC</th><th class='right'>Ext (BWP)</th></tr>";
   $total = 0.0;
   foreach ($rows as $r) {
     $m = (float)($r['measured_qty'] ?? 0);
@@ -120,7 +120,7 @@ $router->get('/batches/view', function () {
   ");
   $po->execute([$id]); $packs = $po->fetchAll();
 
-  $packTable = "<table><tr><th>Package</th><th class='right'>Units</th><th class='right'>Nominal g</th><th class='right'>Total g</th></tr>";
+  $packTable = table_open() . "<tr><th>Package</th><th class='right'>Units</th><th class='right'>Nominal g</th><th class='right'>Total g</th></tr>";
   $packTotal = 0.0;
   foreach ($packs as $p) {
     $u = (int)$p['unit_count'];
@@ -216,7 +216,7 @@ $router->get('/batches/new', function() {
 
       <h2>Ingredients checklist</h2>";
 
-  $tbl = "<table id='chk'><tr>
+  $tbl = table_open("id='chk'") . "<tr>
             <th class='left'>Group</th>
             <th class='left'>Ingredient</th>
             <th>Recipe qty</th>
@@ -631,7 +631,7 @@ $router->get('/batches/edit', function () {
     <h2>Ingredients checklist (adjust if needed)</h2>";
 
   // Build table (like /batches/new) but pre-filled from resolutions
-  $tbl = "<table id='chk'><tr>
+  $tbl = table_open("id='chk'") . "<tr>
             <th class='left'>Group</th>
             <th class='left'>Ingredient</th>
             <th>Scaled qty</th>

--- a/routes/enrich.php
+++ b/routes/enrich.php
@@ -6,7 +6,7 @@ $router->get('/admin/enrich', function() {
   if (!function_exists('enrich_one')) { http_response_code(404); render('Enrich', "<p class='err'>Enrichment module not installed.</p>"); return; }
   global $pdo;
   $rows = $pdo->query("SELECT id,name,solids_pct,fat_pct,sugar_pct,nutrition_source,nutrition_confidence FROM ingredients WHERE is_active=1 ORDER BY name")->fetchAll();
-  $list = "<table><tr><th>Name</th><th>Solids%</th><th>Fat%</th><th>Sugar%</th><th>Source</th><th>Conf</th><th>Actions</th></tr>";
+  $list = table_open() . "<tr><th>Name</th><th>Solids%</th><th>Fat%</th><th>Sugar%</th><th>Source</th><th>Conf</th><th>Actions</th></tr>";
   foreach ($rows as $r) {
     $missing = [];
     foreach (['solids_pct','fat_pct','sugar_pct'] as $k) if ($r[$k] === null) $missing[] = $k;

--- a/routes/fx_admin.php
+++ b/routes/fx_admin.php
@@ -10,7 +10,7 @@ $router->get('/admin/fx', function() {
     LIMIT 200
   ")->fetchAll();
 
-  $tbl = "<table><tr><th>Date</th><th>Currency</th><th>Rate → BWP</th></tr>";
+  $tbl = table_open() . "<tr><th>Date</th><th>Currency</th><th>Rate → BWP</th></tr>";
   foreach ($rows as $r) {
     $tbl .= "<tr><td>".h($r['rate_date'])."</td><td>".h($r['currency'])."</td>"
           . "<td class='right'>".number_format((float)$r['rate_to_bwp'],6)."</td></tr>";

--- a/routes/ingredients.php
+++ b/routes/ingredients.php
@@ -32,7 +32,7 @@ $router->get('/ingredients', function() {
   }
   $nav = $navLinks ? "<p class='pager'>".implode(' | ', $navLinks)."</p>" : '';
 
-  $list = "<table><tr><th>Name</th><th>Unit</th><th>On hand</th><th>WAC (BWP/u)</th><th>Reorder</th>";
+  $list = table_open() . "<tr><th>Name</th><th>Unit</th><th>On hand</th><th>WAC (BWP/u)</th><th>Reorder</th>";
   if (role_is('admin')) { $list .= "<th>Actions</th>"; }
   $list .= "</tr>";
 

--- a/routes/inventory.php
+++ b/routes/inventory.php
@@ -151,7 +151,7 @@ $router->get('/inventory/history', function () {
   ");
   $tx->execute([$id]); $rows = $tx->fetchAll();
 
-  $tbl = "<table><tr><th>Date</th><th>Type</th><th class='right'>Qty</th><th>Unit</th><th>Note</th></tr>";
+  $tbl = table_open() . "<tr><th>Date</th><th>Type</th><th class='right'>Qty</th><th>Unit</th><th>Note</th></tr>";
   foreach ($rows as $r) {
     $tbl .= "<tr>
       <td>".h($r['txn_date'])."</td>

--- a/routes/po.php
+++ b/routes/po.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
         LIMIT 200
       ")->fetchAll();
     
-      $list = "<table>
-        <tr><th>Date</th><th>PO #</th><th>Supplier</th>
+      $list = table_open()
+        . "<tr><th>Date</th><th>PO #</th><th>Supplier</th>
             <th class='right'>Lines</th><th class='right'>Total (BWP)</th><th>Actions</th></tr>";
     
       foreach ($rows as $r) {
@@ -90,7 +90,7 @@ declare(strict_types=1);
                • Currency: ".h($H['currency'])." @ ".number_format((float)$H['fx_rate_used'],6)."</p>
             <p><a href='".url_for("/po/edit?id=".$id)."'>Edit this PO</a></p>";
 
-    $tbl = "<table><tr><th>Ingredient</th><th class='right'>Qty</th><th>Unit</th>
+    $tbl = table_open() . "<tr><th>Ingredient</th><th class='right'>Qty</th><th>Unit</th>
                    <th class='right'>Unit cost (native)</th><th class='right'>Unit cost (BWP)</th><th>Note</th></tr>";
     $total = 0.0;
     foreach ($L as $r) {
@@ -148,7 +148,7 @@ declare(strict_types=1);
       </div>
 
       <fieldset><legend>Lines</legend>
-        <table>
+        ".table_open()."
           <thead>
             <tr><th>Ingredient</th><th>Qty (canonical)</th><th>Line total (native)</th><th>Note</th><th></th></tr>
           </thead>
@@ -334,7 +334,7 @@ declare(strict_types=1);
         </div>";
 
     $tbl = "<fieldset><legend>Lines</legend>
-      <table>
+      ".table_open()."
         <thead>
           <tr><th>Ingredient</th><th>Qty (canonical)</th><th>Line total (native)</th><th>Note</th><th></th></tr>
         </thead>

--- a/routes/recipes.php
+++ b/routes/recipes.php
@@ -24,7 +24,7 @@ $router->get('/recipes', function () {
   $byRecipe = [];
   foreach ($allv as $v) { $byRecipe[(int)$v['recipe_id']][] = $v; }
 
-  $list = "<table><tr><th>Name</th><th>Style</th><th>Versions</th><th>Actions</th></tr>";
+  $list = table_open() . "<tr><th>Name</th><th>Style</th><th>Versions</th><th>Actions</th></tr>";
   foreach ($rs as $r) {
     $rid = (int)$r['rid'];
     $links = '—';
@@ -248,9 +248,9 @@ $router->get('/recipes/view', function () {
   </div>";
 
   // Ingredients table (includes per-line extended cost and the per-ingredient step note)
-  $tbl = "<h2>Ingredients</h2>
-  <table>
-    <tr>
+  $tbl = "<h2>Ingredients</h2>"
+    . table_open()
+    . "<tr>
       <th>Group</th><th class='left'>Ingredient</th><th class='right'>Qty</th><th>Unit</th>
       <th>Primary</th><th class='right'>Cost (BWP)</th><th class='left'>Step notes</th>
     </tr>";
@@ -304,7 +304,7 @@ $router->get('/recipes/items', function() {
                           ORDER BY ri.choice_group, ri.sort_order, i.name");
   $items->execute([$rv_id]); $rows = $items->fetchAll();
 
-    $tbl = "<table><tr>
+    $tbl = table_open() . "<tr>
       <th>Group</th><th>Ingredient</th><th>Qty</th><th>Unit</th>
       <th>Primary</th><th>Cost (BWP)</th><th>Step notes</th><th>Actions</th>
     </tr>";


### PR DESCRIPTION
## Summary
- add a `table_open` helper that always applies the shared `table` class
- update every route that renders tables to build them through the helper

## Testing
- php -l app/ui.php
- php -l routes/ingredients.php
- php -l routes/inventory.php
- php -l routes/enrich.php
- php -l routes/fx_admin.php
- php -l routes/admin_tools.php
- php -l routes/batches.php
- php -l routes/recipes.php
- php -l routes/po.php

------
https://chatgpt.com/codex/tasks/task_e_68cbf39b9ee4832187795946118ef17f