### PR TITLE
Add GitHub Actions workflow for PHP and shell linting

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,39 @@
+name: PHP and Shell Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run PHP lint
+        run: |
+          set -eo pipefail
+          php_files=$(find . -type f -name '*.php')
+          if [ -n "$php_files" ]; then
+            for file in $php_files; do
+              php -l "$file"
+            done
+          else
+            echo "No PHP files to lint."
+          fi
+
+      - name: Run ShellCheck
+        run: |
+          set -eo pipefail
+          if compgen -G 'bin/*.sh' > /dev/null; then
+            shellcheck bin/*.sh
+          else
+            echo "No shell scripts to lint."
+          fi


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs PHP syntax checks across all PHP files
- ensure shell scripts in bin/ are linted with ShellCheck

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68cc0498407883218185a8421b03e40d